### PR TITLE
add a shorthand version of the dequeue command

### DIFF
--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -24,7 +24,7 @@ module Lita
       )
 
       route(
-        /^locker\sdequeue\s#{LABEL_REGEX}$/,
+        /^locker\s(dq|dequeue)\s#{LABEL_REGEX}$/,
         :dequeue,
         command: true,
         help: { t('help.dequeue.syntax') => t('help.dequeue.desc') }

--- a/spec/lita/handlers/locker_misc_spec.rb
+++ b/spec/lita/handlers/locker_misc_spec.rb
@@ -26,6 +26,11 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
     is_expected.to route_command('locker log something').to(:log)
   end
 
+  it do
+    is_expected.to route_command('locker dequeue something something').to(:dequeue)
+    is_expected.to route_command('locker dq something something').to(:dequeue)
+  end
+
   let(:alice) do
     Lita::User.create('9001@hipchat', name: 'Alice', mention_name: 'alice')
   end


### PR DESCRIPTION
The dequeue feature is awesome, but my ability to repeatedly type it correctly is not. This adds a shorthand version of dequeue `dq` to make that easier.

In addition, explicity assertions for routing of the `dequeue` command has been added.