### PR TITLE
[#42] Allow for a lock owner to transfer a lock to someone else

### DIFF
--- a/lib/lita/handlers/locker.rb
+++ b/lib/lita/handlers/locker.rb
@@ -42,7 +42,7 @@ module Lita
       )
 
       route(
-        /^give\s#{LABEL_REGEX}\sto\s#{USER_REGEX}#{COMMENT_REGEX}$/,
+        /^locker\sgive\s#{LABEL_REGEX}\sto\s#{USER_REGEX}#{COMMENT_REGEX}$/,
         :give,
         command: true,
         help: { t('help.give.syntax') => t('help.give.desc') }

--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -58,11 +58,7 @@ module Lita
         return response.reply(t('subject.does_not_exist', name: name)) unless Label.exists?(name)
         l = Label.new(name)
         l.wait_queue.delete(response.user.id)
-        queued = l.wait_queue.to_a
-        l.wait_queue.clear
-        queued.chunk { |x| x }.map(&:first).each do |user|
-          l.wait_queue << user
-        end
+        l.dedupe!
         response.reply(t('label.removed_from_queue', name: name))
       end
 

--- a/lib/locker/label.rb
+++ b/lib/locker/label.rb
@@ -103,7 +103,23 @@ module Locker
       def steal!(owner_id)
         log("Stolen from #{owner.id} to #{owner_id}")
         wait_queue.unshift(owner_id)
+        self.dedupe!
         self.unlock!
+      end
+
+      def give!(recipient_id)
+        log("Given from #{owner.id} to #{recipient_id}")
+        wait_queue.unshift(recipient_id)
+        self.dedupe!
+        self.unlock!
+      end
+
+      def dedupe!
+        queued = wait_queue.to_a
+        wait_queue.clear
+        queued.chunk { |x| x }.map(&:first).each do |user|
+          wait_queue << user
+        end
       end
 
       def add_observer!(observer_id)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,10 @@ en:
           stolen: "%{label} stolen from %{old_owner} %{mention}"
           already_unlocked: "%{label} was already unlocked"
           self: Why are you stealing the lock from yourself?
+        give:
+          not_owner: "The lock on %{label} can only be given by its current owner: %{owner} %{mention}"
+          given: "%{giver} gave %{label} to %{recipient} %{mention}"
+          self: Why are you giving the lock to yourself?
         observe:
           now_observing: "Now observing %{name}"
           already_observing: "You are already observing %{name}"
@@ -33,6 +37,9 @@ en:
           steal:
             syntax: steal <subject>
             desc: Force removal of a reservation. Can have # comments afterwards.
+          give:
+            syntax: give <subject> to <username>
+            desc: Transfer ownership of a lock to another user. Can have # comments afterwards.
           status:
             syntax: locker status <label or resource>
             desc: Show the current state of <label or resource>

--- a/spec/lita/handlers/locker_misc_spec.rb
+++ b/spec/lita/handlers/locker_misc_spec.rb
@@ -80,7 +80,7 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
       send_command('lock foo', as: bob)
       send_command('locker dequeue foo', as: doris)
       send_command('locker status foo')
-      expect(replies.last).to eq('foo is locked by Alice (taken 1 second ago). Next up: Bob')
+      expect(replies.last).to match(/^foo is locked by Alice \(taken \d seconds? ago\)\. Next up: Bob$/)
     end
   end
 
@@ -93,13 +93,13 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
       expect(replies.last).to eq('foo is unlocked')
       send_command('lock foo')
       send_command('locker status foo')
-      expect(replies.last).to eq('foo is locked by Test User (taken 1 second ago)')
+      expect(replies.last).to match(/^foo is locked by Test User \(taken \d seconds? ago\)$/)
       send_command('lock foo', as: alice)
       send_command('locker status foo')
-      expect(replies.last).to eq('foo is locked by Test User (taken 1 second ago). Next up: Alice')
+      expect(replies.last).to match(/^foo is locked by Test User \(taken \d seconds? ago\)\. Next up: Alice$/)
       send_command('lock foo', as: bob)
       send_command('locker status foo')
-      expect(replies.last).to eq('foo is locked by Test User (taken 1 second ago). Next up: Alice, Bob')
+      expect(replies.last).to match(/^foo is locked by Test User \(taken \d seconds? ago\)\. Next up: Alice, Bob$/)
     end
 
     it 'shows the status of a resource' do

--- a/spec/lita/handlers/locker_spec.rb
+++ b/spec/lita/handlers/locker_spec.rb
@@ -30,6 +30,8 @@ describe Lita::Handlers::Locker, lita_handler: true do
       is_expected.to route_command("steal #{l}").to(:steal)
       is_expected.to route_command("steal #{l} ").to(:steal)
       is_expected.to route_command("steal #{l} #this is a comment").to(:steal)
+      is_expected.to route_command("locker give #{l} to alice").to(:give)
+      is_expected.to route_command("locker give #{l} to alice #this is a comment").to(:give)
       is_expected.to route_command("locker observe #{l}").to(:observe)
       is_expected.to route_command("locker observe #{l} #this is a comment").to(:observe)
       is_expected.to route_command("locker unobserve #{l}").to(:unobserve)
@@ -277,7 +279,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label create bazbat')
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
-      send_command('give bazbat to @bob # with a comment', as: alice)
+      send_command('locker give bazbat to @bob # with a comment', as: alice)
       expect(replies.last).to eq('Alice gave bazbat to Bob (@bob)')
     end
 
@@ -288,7 +290,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('lock bazbat', as: alice)
       send_command('lock bazbat', as: bob)
       send_command('lock bazbat', as: charlie)
-      send_command('give bazbat to @charlie # with a comment', as: alice)
+      send_command('locker give bazbat to @charlie # with a comment', as: alice)
       send_command('locker status bazbat')
       expect(replies.last).to match(/^bazbat is locked by Charlie \(taken \d seconds? ago\)\. Next up: Bob, Charlie$/)
     end
@@ -298,7 +300,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label create bazbat')
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
-      send_command('give bazbat to @alice # with a comment', as: alice)
+      send_command('locker give bazbat to @alice # with a comment', as: alice)
       expect(replies.last).to eq('Why are you giving the lock to yourself?')
     end
 
@@ -307,12 +309,12 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label create bazbat')
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
-      send_command('give bazbat to @charlie # with a comment', as: bob)
+      send_command('locker give bazbat to @charlie # with a comment', as: bob)
       expect(replies.last).to eq('The lock on bazbat can only be given by its current owner: Alice (@alice)')
     end
 
     it 'shows an error when the label does not exist' do
-      send_command('give foobar to @bob', as: alice)
+      send_command('locker give foobar to @bob', as: alice)
       expect(replies.last).to eq('Sorry, that does not exist')
     end
 
@@ -321,7 +323,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label create bazbat')
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
-      send_command('give bazbat to @doris', as: alice)
+      send_command('locker give bazbat to @doris', as: alice)
       expect(replies.last).to eq('Unknown user')
     end
   end


### PR DESCRIPTION
This pull request adds the `give` command in order to address issue #42. The deduplication logic added in v1.0.3 has been made into the Label method `dedupe!` and reused in `give!` and `steal!`. The addition of this method seems to have caused some tests to return "(taken 2 seconds ago)", which is why they have been rewritten as regular expressions.