### PR TITLE
[#45] Allow status checks for multiple labels with wildcard operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ steal <label>                 - Force removal of a reservation.  This can be don
 locker give <label> to <user> - Transfer ownership of a lock to another user.  This can only be done by the lock's current owner. Can have # comments afterwards.
 ```
 
+### Status
+```
+locker status <label or resource>  - Show the current state of <label or resource>
+locker list <username>             - Show what locks a user currently holds
+locker log <label>                 - Show up to the last 10 activity log entries for <label>
+locker observe <label>             - Get a notification when <label> becomes available
+locker unobserve <label>           - Stop getting notifications when <label> becomes available
+```
+
 ### Queueing
 ```
 lock <label>           - If <label> is already locked, adds you to a FIFO queue of pending reservations for <label>

--- a/lib/locker/regex.rb
+++ b/lib/locker/regex.rb
@@ -2,13 +2,14 @@
 module Locker
   # Regex definitions
   module Regex
-    LABEL_REGEX    = /(?<label>[\.\w\s-]+)(\s)?/
-    LABELS_REGEX   = /(?<labels>[\.\w\s-]+(?:,\s*[\.\w\s-]+)*)(\s)?/
-    RESOURCE_REGEX = /(?<resource>[\.\w-]+)/
-    RESOURCES_REGEX = /(?<resources>[\.\w-]+(?:,\s*[\.\w-]+)*)/
-    COMMENT_REGEX  = /(\s\#.+)?/
-    LOCK_REGEX     = /\(lock\)\s/i
-    USER_REGEX     = /(?:@)?(?<username>[\w\s-]+)/
-    UNLOCK_REGEX   = /(?:\(unlock\)|\(release\))\s/i
+    LABEL_REGEX           = /(?<label>[\.\w\s-]+)(\s)?/
+    LABEL_WILDCARD_REGEX  = /(?<label>[\.\*\w\s-]+)(\s)?/
+    LABELS_REGEX          = /(?<labels>[\.\w\s-]+(?:,\s*[\.\w\s-]+)*)(\s)?/
+    RESOURCE_REGEX        = /(?<resource>[\.\w-]+)/
+    RESOURCES_REGEX       = /(?<resources>[\.\w-]+(?:,\s*[\.\w-]+)*)/
+    COMMENT_REGEX         = /(\s\#.+)?/
+    LOCK_REGEX            = /\(lock\)\s/i
+    USER_REGEX            = /(?:@)?(?<username>[\w\s-]+)/
+    UNLOCK_REGEX          = /(?:\(unlock\)|\(release\))\s/i
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,22 +23,22 @@ en:
             syntax: locker dequeue <label>
             desc: Remove yourself from the queue for a label
           lock:
-            syntax: lock <subject>
+            syntax: lock <label>
             desc: "Make something unavailable to others. Can have # comments afterwards."
           unlock:
-            syntax: unlock <subject>
+            syntax: unlock <label>
             desc: "Make something available to others. Can have # comments afterwards."
           observe:
-            syntax: locker observe <subject>
+            syntax: locker observe <label>
             desc: "Get a notification when something becomes available. Can have # comments afterwards."
           unobserve:
-            syntax: locker unobserve <subject>
+            syntax: locker unobserve <label>
             desc: "Stop getting notifications when something becomes available. Can have # comments afterwards."
           steal:
-            syntax: steal <subject>
+            syntax: steal <label>
             desc: "Force removal of a reservation. Can have # comments afterwards."
           give:
-            syntax: locker give <subject> to <username>
+            syntax: locker give <label> to <username>
             desc: "Transfer ownership of a lock to another user. Can have # comments afterwards."
           status:
             syntax: locker status <label or resource>

--- a/spec/lita/handlers/locker_misc_spec.rb
+++ b/spec/lita/handlers/locker_misc_spec.rb
@@ -17,6 +17,8 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
     it { is_expected.to route_command("locker status #{r}").to(:status) }
   end
 
+  it { is_expected.to route_command('locker status foo*').to(:status) }
+
   it do
     is_expected.to route_command('locker list @alice').to(:list)
     is_expected.to route_command('locker list Alice').to(:list)
@@ -111,6 +113,22 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
       send_command('lock foo')
       send_command('locker status bar')
       expect(replies.last).to eq('Resource: bar, state: locked')
+    end
+
+    it 'allows label wildcard search with an asterisk' do
+      send_command('locker resource create foobarbaz')
+      send_command('locker label create foobar')
+      send_command('locker label add foobarbaz to foobar')
+      send_command('locker resource create foobazbar')
+      send_command('locker label create foobaz')
+      send_command('locker label add foobazbar to foobaz')
+      send_command('locker resource create bazbarluhrmann')
+      send_command('locker label create bazbar')
+      send_command('locker label add bazbarluhrmann to bazbar')
+      send_command('lock foobar')
+      send_command('locker status foo*')
+      expect(replies[-2]).to match(/^foobar is locked by Test User \(taken \d seconds? ago\)$/)
+      expect(replies.last).to match(/^foobaz is unlocked$/)
     end
 
     it 'shows an error if nothing exists with that name' do


### PR DESCRIPTION
With this change, a user will be able to send the command `locker status
foo*` and receive information about the labels foo1, foo2, foo3, etc.