### PR TITLE
Fix unintended behavior with locker status

### DIFF
--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -52,11 +52,12 @@ module Lita
           # Literal query
           return response.reply(status_label(name)) if Label.exists?(name)
           return response.reply(status_resource(name)) if Resource.exists?(name)
+          return response.reply(failed(t('status.does_not_exist', name: name)))
         end
         # Wildcard query
         matcher = Regexp.new(name.gsub(/\*/, '.*'))
         labels = Label.list.select { |label| label =~ matcher }
-        return response.reply(failed(t('subject.does_not_exist', name: name))) if labels.empty?
+        return response.reply(failed(t('status.does_not_exist', name: name))) if labels.empty?
         labels.each do |n|
           response.reply(status_label(n))
         end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -42,7 +42,7 @@ en:
             desc: "Transfer ownership of a lock to another user. Can have # comments afterwards."
           status:
             syntax: locker status <label or resource>
-            desc: Show the current state of <label or resource>
+            desc: "Show the current state of <label or resource>. Supports wildcard search with *"
           list:
             syntax: locker list <username>
             desc: Show what locks a user currently holds
@@ -90,6 +90,8 @@ en:
           is_unlocked: "%{name} is unlocked"
           owned: "%{name} is locked by %{owner_name}"
           owned_mention: "%{name} is locked by %{owner_name} (@%{owner_mention})"
+        status:
+          does_not_exist: "Sorry, that does not exist. Use * for wildcard search"
         subject:
           does_not_exist: "Sorry, that does not exist"
         label:

--- a/spec/lita/handlers/locker_misc_spec.rb
+++ b/spec/lita/handlers/locker_misc_spec.rb
@@ -132,8 +132,17 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
     end
 
     it 'shows an error if nothing exists with that name' do
+      send_command('locker resource create foobarbaz')
+      send_command('locker label create foobar')
+      send_command('locker label add foobarbaz to foobar')
+      send_command('locker resource create foobazbar')
+      send_command('locker label create foobaz')
+      send_command('locker label add foobazbar to foobaz')
+      send_command('locker resource create bazbarluhrmann')
+      send_command('locker label create bazbar')
+      send_command('locker label add bazbarluhrmann to bazbar')
       send_command('locker status foo')
-      expect(replies.last).to eq('Sorry, that does not exist')
+      expect(replies.last).to eq('Sorry, that does not exist. Use * for wildcard search')
     end
   end
 


### PR DESCRIPTION
Currently, sending `locker status foo` will return foo1, foo2, foo3,
etc. if foo does not exist. This is unintended behavior, as all matching
labels should only be returned in response to an explicit wildcard
search. This change makes the bot respond correctly saying that foo does
not exist, with an additional hint that the user should use * for
wildcard search.

(PD internal JIRA issue DEV-407)