### PR TITLE
Include usernames in relevant replies

### DIFF
--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -69,15 +69,15 @@ module Lita
         l = Label.new(name)
         l.wait_queue.delete(response.user.id)
         l.dedupe!
-        response.reply(t('label.removed_from_queue', name: name))
+        response.reply(t('label.removed_from_queue', name: name, user: response.user.name))
       end
 
       def list(response)
         username = response.match_data['username']
         user = Lita::User.fuzzy_find(username)
-        return response.reply(t('user.unknown')) unless user
+        return response.reply(t('user.unknown', user: username)) unless user
         l = user_locks(user)
-        return response.reply(t('user.no_active_locks')) unless l.size > 0
+        return response.reply(t('user.no_active_locks', user: user.name)) unless l.size > 0
         composed = ''
         l.each do |label_name|
           composed += "Label: #{label_name}\n"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,18 +3,18 @@ en:
     handlers:
       locker:
         steal:
-          stolen: "%{label} stolen from %{old_owner} %{mention}"
+          stolen: "%{thief} stole %{label} from %{victim} %{mention}"
           already_unlocked: "%{label} was already unlocked"
-          self: Why are you stealing the lock from yourself?
+          self: "%{user}, why are you stealing the lock from yourself?"
         give:
           not_owner: "The lock on %{label} can only be given by its current owner: %{owner} %{mention}"
           given: "%{giver} gave %{label} to %{recipient} %{mention}"
-          self: Why are you giving the lock to yourself?
+          self: "%{user}, why are you giving the lock to yourself?"
         observe:
-          now_observing: "Now observing %{name}"
-          already_observing: "You are already observing %{name}"
-          stopped_observing: "You have stopped observing %{name}"
-          were_not_observing: "You were not observing %{name} originally"
+          now_observing: "%{user} is now observing %{name}"
+          already_observing: "%{user}, you are already observing %{name}"
+          stopped_observing: "%{user}, you have stopped observing %{name}"
+          were_not_observing: "%{user}, you were not observing %{name}"
         help:
           log:
             syntax: locker log <label>
@@ -91,12 +91,12 @@ en:
           owned: "%{name} is locked by %{owner_name}"
           owned_mention: "%{name} is locked by %{owner_name} (@%{owner_mention})"
         status:
-          does_not_exist: "Sorry, that does not exist. Use * for wildcard search"
+          does_not_exist: "%{name} does not exist. Use * for wildcard search"
         subject:
-          does_not_exist: "Sorry, that does not exist"
+          does_not_exist: "%{name} does not exist"
         label:
           log_entry: "%{entry}"
-          self_lock: "You already have the lock on %{name}"
+          self_lock: "%{user}, you already have the lock on %{name}"
           unlock: "%{name} unlocked"
           owned_lock: "%{name} is locked by %{owner_name} %{mention} (taken %{time}), you have been added to the queue (currently: %{queue}), type 'locker dequeue %{name}' to be removed"
           owned_unlock: "%{name} is locked by %{owner_name} %{mention} (taken %{time})"
@@ -110,7 +110,7 @@ en:
           created: "Label %{name} created"
           exists: "%{name} already exists"
           deleted: "Label %{name} deleted"
-          does_not_exist: "Label %{name} does not exist.  To create it: \"!locker label create %{name}\""
+          does_not_exist: "Label %{name} does not exist. To create it: \"!locker label create %{name}\""
           has_no_resources: "Label %{name} has no resources"
           resource_added: "Resource %{resource} has been added to %{label}"
           resource_removed: "Resource %{resource} has been removed from %{label}"
@@ -119,8 +119,8 @@ en:
           no_resources: "%{name} has no resources, so it cannot be locked"
           dependency: 'Label unable to be locked, blocked on:'
           now_locked_by: "%{name} now locked by %{owner} %{mention}"
-          removed_from_queue: "You have been removed from the queue for %{name}"
-          unknown_in_queue: "You weren't in the queue for %{name}"
+          removed_from_queue: "%{user} has been removed from the queue for %{name}"
+          unknown_in_queue: "%{user}, you weren't in the queue for %{name}"
         user:
-          unknown: Unknown user
-          no_active_locks: That user has no active locks
+          unknown: "Unknown user '%{user}'"
+          no_active_locks: "%{user} has no active locks"

--- a/spec/lita/handlers/locker_labels_spec.rb
+++ b/spec/lita/handlers/locker_labels_spec.rb
@@ -81,7 +81,7 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
 
     it 'shows a warning when <name> does not exist' do
       send_command('locker label delete foobar')
-      expect(replies.last).to eq('Label foobar does not exist.  To create it: "!locker label create foobar"')
+      expect(replies.last).to eq('Label foobar does not exist. To create it: "!locker label create foobar"')
     end
 
     it 'accepts a comma-separated list of labels' do
@@ -108,7 +108,7 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
 
     it 'shows an error if the label does not exist' do
       send_command('locker label show foobar')
-      expect(replies.last).to eq('Label foobar does not exist.  To create it: "!locker label create foobar"')
+      expect(replies.last).to eq('Label foobar does not exist. To create it: "!locker label create foobar"')
     end
   end
 
@@ -144,7 +144,7 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
 
     it 'shows an error if the label does not exist' do
       send_command('locker label add foo to bar')
-      expect(replies.last).to eq('Label bar does not exist.  To create it: "!locker label create bar"')
+      expect(replies.last).to eq('Label bar does not exist. To create it: "!locker label create bar"')
     end
 
     it 'shows an error if the resource does not exist' do
@@ -182,12 +182,12 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
 
     it 'shows an error if the label does not exist' do
       send_command('locker label add foo to bar')
-      expect(replies.last).to eq('Label bar does not exist.  To create it: "!locker label create bar"')
+      expect(replies.last).to eq('Label bar does not exist. To create it: "!locker label create bar"')
     end
 
     it 'shows an error if the label does not exist when given a list of resources' do
       send_command('locker label add foo, baz to bar')
-      expect(replies.last).to eq('Label bar does not exist.  To create it: "!locker label create bar"')
+      expect(replies.last).to eq('Label bar does not exist. To create it: "!locker label create bar"')
     end
 
     it 'shows an error if the resource does not exist' do

--- a/spec/lita/handlers/locker_misc_spec.rb
+++ b/spec/lita/handlers/locker_misc_spec.rb
@@ -57,7 +57,7 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
 
     it 'shows a warning if the label does not exist' do
       send_command('locker log something')
-      expect(replies.last).to eq('Sorry, that does not exist')
+      expect(replies.last).to eq('something does not exist')
     end
   end
 
@@ -69,7 +69,7 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
       send_command('lock foo', as: alice)
       send_command('lock foo', as: bob)
       send_command('locker dequeue foo', as: bob)
-      expect(replies.last).to eq('You have been removed from the queue for foo')
+      expect(replies.last).to eq('Bob has been removed from the queue for foo')
     end
 
     it 'avoids adjacent duplicates in the queue when a sandwiched dequeue occurs' do
@@ -142,7 +142,7 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
       send_command('locker label create bazbar')
       send_command('locker label add bazbarluhrmann to bazbar')
       send_command('locker status foo')
-      expect(replies.last).to eq('Sorry, that does not exist. Use * for wildcard search')
+      expect(replies.last).to eq('foo does not exist. Use * for wildcard search')
     end
   end
 
@@ -179,16 +179,16 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
       send_command('locker label create bazbat')
       send_command('locker label add foobar to bazbat')
       send_command('locker list Alice', as: alice)
-      expect(replies.last).to eq('That user has no active locks')
+      expect(replies.last).to eq('Alice has no active locks')
       send_command('lock bazbat', as: alice)
       send_command('unlock bazbat', as: alice)
       send_command('locker list Alice', as: alice)
-      expect(replies.last).to eq('That user has no active locks')
+      expect(replies.last).to eq('Alice has no active locks')
     end
 
     it 'shows a warning when the user does not exist' do
       send_command('locker list foobar')
-      expect(replies.last).to eq('Unknown user')
+      expect(replies.last).to eq("Unknown user 'foobar'")
     end
   end
 end

--- a/spec/lita/handlers/locker_spec.rb
+++ b/spec/lita/handlers/locker_spec.rb
@@ -74,9 +74,9 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker resource create foobar')
       send_command('locker label create bazbat')
       send_command('locker label add foobar to bazbat')
-      send_command('lock bazbat')
-      send_command('lock bazbat')
-      expect(replies.last).to eq('You already have the lock on bazbat')
+      send_command('lock bazbat', as: alice)
+      send_command('lock bazbat', as: alice)
+      expect(replies.last).to eq('Alice, you already have the lock on bazbat')
     end
 
     it 'does not add a user multiple times to the end of a queue' do
@@ -134,7 +134,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
 
     it 'shows an error when a label does not exist' do
       send_command('lock foobar')
-      expect(replies.last).to eq('Label foobar does not exist.  To create it: "!locker label create foobar"')
+      expect(replies.last).to eq('Label foobar does not exist. To create it: "!locker label create foobar"')
     end
 
     context 'when mentioning a user' do
@@ -255,7 +255,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
 
     it 'shows an error when a <subject> does not exist' do
       send_command('unlock foobar')
-      expect(replies.last).to eq('Sorry, that does not exist')
+      expect(replies.last).to eq('foobar does not exist')
     end
   end
 
@@ -266,7 +266,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
       send_command('steal bazbat # with a comment', as: bob)
-      expect(replies.last).to eq('bazbat stolen from Alice (@alice)')
+      expect(replies.last).to eq('Bob stole bazbat from Alice (@alice)')
     end
 
     it 'preserves the state of the queue when there is one' do
@@ -294,12 +294,12 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
       send_command('steal bazbat # with a comment', as: alice)
-      expect(replies.last).to eq('Why are you stealing the lock from yourself?')
+      expect(replies.last).to eq('Alice, why are you stealing the lock from yourself?')
     end
 
     it 'shows an error when a <subject> does not exist' do
       send_command('steal foobar')
-      expect(replies.last).to eq('Sorry, that does not exist')
+      expect(replies.last).to eq('foobar does not exist')
     end
   end
 
@@ -331,7 +331,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
       send_command('locker give bazbat to @alice # with a comment', as: alice)
-      expect(replies.last).to eq('Why are you giving the lock to yourself?')
+      expect(replies.last).to eq('Alice, why are you giving the lock to yourself?')
     end
 
     it 'shows an error when the attempted giver is not the owner' do
@@ -345,7 +345,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
 
     it 'shows an error when the label does not exist' do
       send_command('locker give foobar to @bob', as: alice)
-      expect(replies.last).to eq('Sorry, that does not exist')
+      expect(replies.last).to eq('foobar does not exist')
     end
 
     it 'shows an error when the recipient does not exist' do
@@ -354,7 +354,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label add foobar to bazbat')
       send_command('lock bazbat', as: alice)
       send_command('locker give bazbat to @doris', as: alice)
-      expect(replies.last).to eq('Unknown user')
+      expect(replies.last).to eq("Unknown user 'doris'")
     end
   end
 
@@ -364,7 +364,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label create bazbat')
       send_command('locker label add foobar to bazbat')
       send_command('locker observe bazbat', as: alice)
-      expect(replies.last).to eq('Now observing bazbat')
+      expect(replies.last).to eq('Alice is now observing bazbat')
     end
 
     it 'warns user if already observing label' do
@@ -373,7 +373,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label add foobar to bazbat')
       send_command('locker observe bazbat', as: alice)
       send_command('locker observe bazbat', as: alice)
-      expect(replies.last).to eq('You are already observing bazbat')
+      expect(replies.last).to eq('Alice, you are already observing bazbat')
     end
   end
 
@@ -384,7 +384,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker label add foobar to bazbat')
       send_command('locker observe bazbat', as: alice)
       send_command('locker unobserve bazbat', as: alice)
-      expect(replies.last).to eq('You have stopped observing bazbat')
+      expect(replies.last).to eq('Alice, you have stopped observing bazbat')
     end
 
     it 'warns user if already not observing label' do
@@ -394,7 +394,7 @@ describe Lita::Handlers::Locker, lita_handler: true do
       send_command('locker observe bazbat', as: alice)
       send_command('locker unobserve bazbat', as: alice)
       send_command('locker unobserve bazbat', as: alice)
-      expect(replies.last).to eq('You were not observing bazbat originally')
+      expect(replies.last).to eq('Alice, you were not observing bazbat')
     end
   end
 end


### PR DESCRIPTION
Make the bot send responses that explicitly address the interlocutor in
order to reduce confusion in high-volume channels.
(PD internal issue DEV-325)