### PR TITLE
Prevent someone from giving a label that is not locked

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --profile 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ LineLength:
   Max: 130
 
 AbcSize:
-  Max: 30
+  Max: 34
 
 MethodLength:
   Max: 20

--- a/lib/lita/handlers/locker.rb
+++ b/lib/lita/handlers/locker.rb
@@ -90,10 +90,10 @@ module Lita
 
         return if l.locked?
         mention_names = l.observers
-                        .map { |observer| render_template('mention', name: observer.mention_name, id: observer.id) }
-                        .reject { |mention| mention == '' }
-                        .sort
-                        .join(' ')
+                         .map { |observer| render_template('mention', name: observer.mention_name, id: observer.id) }
+                         .reject { |mention| mention == '' }
+                         .sort
+                         .join(' ')
         response.reply(t('label.unlocked_no_queue', name: name, mention: mention_names)) unless mention_names.empty?
       end
 

--- a/lib/lita/handlers/locker.rb
+++ b/lib/lita/handlers/locker.rb
@@ -132,6 +132,7 @@ module Lita
 
         return response.reply(failed(t('subject.does_not_exist', name: name))) unless Label.exists?(name)
         l = Label.new(name)
+        return response.reply(failed(t('give.not_owned', label: name))) unless l.locked?
         owner_mention = render_template('mention', name: l.owner.mention_name, id: l.owner.id)
         return response.reply(t('give.not_owner',
                                 label: name,

--- a/lib/lita/handlers/locker_labels.rb
+++ b/lib/lita/handlers/locker_labels.rb
@@ -75,11 +75,11 @@ module Lita
         results = []
 
         names.each do |name|
-          if !Label.exists?(name) && Label.create(name)
-            results <<= t('label.created', name: name)
-          else
-            results <<= t('label.exists', name: name)
-          end
+          results <<= if !Label.exists?(name) && Label.create(name)
+                        t('label.created', name: name)
+                      else
+                        t('label.exists', name: name)
+                      end
         end
 
         response.reply(results.join(', '))
@@ -90,11 +90,11 @@ module Lita
         results = []
 
         names.each do |name|
-          if Label.exists?(name) && Label.delete(name)
-            results <<= t('label.deleted', name: name)
-          else
-            results <<= failed(t('label.does_not_exist', name: name))
-          end
+          results <<= if Label.exists?(name) && Label.delete(name)
+                        t('label.deleted', name: name)
+                      else
+                        failed(t('label.does_not_exist', name: name))
+                      end
         end
 
         response.reply(results.join(', '))

--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -79,7 +79,7 @@ module Lita
         user = Lita::User.fuzzy_find(username)
         return response.reply(t('user.unknown', user: username)) unless user
         l = user_locks(user)
-        return response.reply(t('user.no_active_locks', user: user.name)) unless l.size > 0
+        return response.reply(t('user.no_active_locks', user: user.name)) if l.empty?
         composed = ''
         l.each do |label_name|
           composed += "Label: #{label_name}\n"

--- a/lib/locker/resource.rb
+++ b/lib/locker/resource.rb
@@ -15,7 +15,7 @@ module Locker
       attr_reader :id
 
       def initialize(key)
-        fail 'Unknown resource key' unless Resource.exists?(key)
+        raise 'Unknown resource key' unless Resource.exists?(key)
         @id = key
       end
 
@@ -24,7 +24,7 @@ module Locker
       end
 
       def self.create(key)
-        fail 'Resource key already exists' if Resource.exists?(key)
+        raise 'Resource key already exists' if Resource.exists?(key)
         redis.sadd('resource-list', key)
         r = Resource.new(key)
         r.state    = 'unlocked'
@@ -33,7 +33,7 @@ module Locker
       end
 
       def self.delete(key)
-        fail 'Unknown resource key' unless Resource.exists?(key)
+        raise 'Unknown resource key' unless Resource.exists?(key)
         %w(state, owner_id).each do |item|
           redis.del("resource:#{key}:#{item}")
         end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -7,6 +7,7 @@ en:
           already_unlocked: "%{label} was already unlocked"
           self: "%{user}, why are you stealing the lock from yourself?"
         give:
+          not_owned: "%{label} is not currently locked, so it cannot be given"
           not_owner: "The lock on %{label} can only be given by its current owner: %{owner} %{mention}"
           given: "%{giver} gave %{label} to %{recipient} %{mention}"
           self: "%{user}, why are you giving the lock to yourself?"

--- a/spec/lita/handlers/locker_http_spec.rb
+++ b/spec/lita/handlers/locker_http_spec.rb
@@ -24,7 +24,7 @@ describe Lita::Handlers::LockerHttp, lita_handler: true do
     it 'shows json if the label exists' do
       send_command('locker label create foo')
       subject.label_show(request, response)
-      expect(response.body).to eq(["{\"id\":\"foo\",\"state\":\"unlocked\",\"membership\":\"\"}"])
+      expect(response.body).to eq(['{"id":"foo","state":"unlocked","membership":""}'])
     end
 
     it 'shows 404 if the label does not exist' do
@@ -38,7 +38,7 @@ describe Lita::Handlers::LockerHttp, lita_handler: true do
       robot.auth.add_user_to_group!(user, :locker_admins)
       send_command('locker resource create foo')
       subject.resource_show(request, response)
-      expect(response.body).to eq(["{\"id\":\"foo\",\"state\":\"unlocked\",\"owner_id\":\"\"}"])
+      expect(response.body).to eq(['{"id":"foo","state":"unlocked","owner_id":""}'])
     end
 
     it 'shows 404 if the resource does not exist' do

--- a/spec/lita/handlers/locker_spec.rb
+++ b/spec/lita/handlers/locker_spec.rb
@@ -325,6 +325,14 @@ describe Lita::Handlers::Locker, lita_handler: true do
       expect(replies.last).to match(/^bazbat is locked by Charlie \(taken \d seconds? ago\)\. Next up: Bob, Charlie$/)
     end
 
+    it 'shows a warning when a give is attempted on an unlocked resource' do
+      send_command('locker resource create foobar')
+      send_command('locker label create bazbat')
+      send_command('locker label add foobar to bazbat')
+      send_command('locker give bazbat to @alice # with a comment', as: bob)
+      expect(replies.last).to eq('bazbat is not currently locked, so it cannot be given')
+    end
+
     it 'shows a warning when the owner attempts to give the label to herself' do
       send_command('locker resource create foobar')
       send_command('locker label create bazbat')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'simplecov'
 require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
@@ -19,4 +19,21 @@ RSpec.configure do |config|
     registry.register_handler(Lita::Handlers::LockerMisc)
     registry.register_handler(Lita::Handlers::LockerResources)
   end
+end
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.order = :random
+
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
This PR does 3 things:

1. Fixes a bug where "locker give foo to bar" when foo is unlocked would cause an error.
1. Cleans up the latest batch of complaints from Rubocop.
1. Cleans up the RSpec config to something a bit more modern.