### PR TITLE
Add comment regex to labels, misc, and resources

### DIFF
--- a/lib/lita/handlers/locker_labels.rb
+++ b/lib/lita/handlers/locker_labels.rb
@@ -10,42 +10,42 @@ module Lita
       include ::Locker::Resource
 
       route(
-        /^locker\slabel\slist$/,
+        /^locker\slabel\slist#{COMMENT_REGEX}$/,
         :list,
         command: true,
         help: { t('help.label.list.syntax') => t('help.label.list.desc') }
       )
 
       route(
-        /^locker\slabel\screate\s#{LABELS_REGEX}$/,
+        /^locker\slabel\screate\s#{LABELS_REGEX}#{COMMENT_REGEX}$/,
         :create,
         command: true,
         help: { t('help.label.create.syntax') => t('help.label.create.desc') }
       )
 
       route(
-        /^locker\slabel\sdelete\s#{LABELS_REGEX}$/,
+        /^locker\slabel\sdelete\s#{LABELS_REGEX}#{COMMENT_REGEX}$/,
         :delete,
         command: true,
         help: { t('help.label.delete.syntax') => t('help.label.delete.desc') }
       )
 
       route(
-        /^locker\slabel\sshow\s#{LABEL_REGEX}$/,
+        /^locker\slabel\sshow\s#{LABEL_REGEX}#{COMMENT_REGEX}$/,
         :show,
         command: true,
         help: { t('help.label.show.syntax') => t('help.label.show.desc') }
       )
 
       route(
-        /^locker\slabel\sadd\s#{RESOURCES_REGEX}\sto\s#{LABEL_REGEX}$/,
+        /^locker\slabel\sadd\s#{RESOURCES_REGEX}\sto\s#{LABEL_REGEX}#{COMMENT_REGEX}$/,
         :add,
         command: true,
         help: { t('help.label.add.syntax') => t('help.label.add.desc') }
       )
 
       route(
-        /^locker\slabel\sremove\s#{RESOURCES_REGEX}\sfrom\s#{LABEL_REGEX}$/,
+        /^locker\slabel\sremove\s#{RESOURCES_REGEX}\sfrom\s#{LABEL_REGEX}#{COMMENT_REGEX}$/,
         :remove,
         command: true,
         help: { t('help.label.remove.syntax') => t('help.label.remove.desc') }

--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -10,28 +10,28 @@ module Lita
       include ::Locker::Resource
 
       route(
-        /^locker\sstatus\s#{LABEL_WILDCARD_REGEX}$/,
+        /^locker\sstatus\s#{LABEL_WILDCARD_REGEX}#{COMMENT_REGEX}$/,
         :status,
         command: true,
         help: { t('help.status.syntax') => t('help.status.desc') }
       )
 
       route(
-        /^locker\slist\s#{USER_REGEX}$/,
+        /^locker\slist\s#{USER_REGEX}#{COMMENT_REGEX}$/,
         :list,
         command: true,
         help: { t('help.list.syntax') => t('help.list.desc') }
       )
 
       route(
-        /^locker\s(dq|dequeue)\s#{LABEL_REGEX}$/,
+        /^locker\s(dq|dequeue)\s#{LABEL_REGEX}#{COMMENT_REGEX}$/,
         :dequeue,
         command: true,
         help: { t('help.dequeue.syntax') => t('help.dequeue.desc') }
       )
 
       route(
-        /^locker\slog\s#{LABEL_REGEX}$/,
+        /^locker\slog\s#{LABEL_REGEX}#{COMMENT_REGEX}$/,
         :log,
         command: true,
         help: { t('help.log.syntax.') => t('help.log.desc') }

--- a/lib/lita/handlers/locker_resources.rb
+++ b/lib/lita/handlers/locker_resources.rb
@@ -10,14 +10,14 @@ module Lita
       include ::Locker::Resource
 
       route(
-        /^locker\sresource\slist$/,
+        /^locker\sresource\slist#{COMMENT_REGEX}$/,
         :list,
         command: true,
         help: { t('help.resource.list.syntax') => t('help.resource.list.desc') }
       )
 
       route(
-        /^locker\sresource\screate\s#{RESOURCES_REGEX}$/,
+        /^locker\sresource\screate\s#{RESOURCES_REGEX}#{COMMENT_REGEX}$/,
         :create,
         command: true,
         restrict_to: [:locker_admins],
@@ -27,7 +27,7 @@ module Lita
       )
 
       route(
-        /^locker\sresource\sdelete\s#{RESOURCES_REGEX}$/,
+        /^locker\sresource\sdelete\s#{RESOURCES_REGEX}#{COMMENT_REGEX}$/,
         :delete,
         command: true,
         restrict_to: [:locker_admins],
@@ -37,7 +37,7 @@ module Lita
       )
 
       route(
-        /^locker\sresource\sshow\s#{RESOURCE_REGEX}$/,
+        /^locker\sresource\sshow\s#{RESOURCE_REGEX}#{COMMENT_REGEX}$/,
         :show,
         command: true,
         help: { t('help.resource.show.syntax') => t('help.resource.show.desc') }

--- a/spec/lita/handlers/locker_labels_spec.rb
+++ b/spec/lita/handlers/locker_labels_spec.rb
@@ -17,6 +17,12 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
       is_expected.to route_command("locker label add foo, bar to #{l}").to(:add)
       is_expected.to route_command("locker label remove resource from #{l}").to(:remove)
       is_expected.to route_command("locker label remove foo, bar from #{l}").to(:remove)
+
+      is_expected.to route_command("locker label create #{l} # comment").to(:create)
+      is_expected.to route_command("locker label delete #{l} # comment").to(:delete)
+      is_expected.to route_command("locker label show #{l} # comment").to(:show)
+      is_expected.to route_command("locker label add resource to #{l} # comment").to(:add)
+      is_expected.to route_command("locker label remove resource from #{l} # comment").to(:remove)
     end
   end
 

--- a/spec/lita/handlers/locker_misc_spec.rb
+++ b/spec/lita/handlers/locker_misc_spec.rb
@@ -18,19 +18,23 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
   end
 
   it { is_expected.to route_command('locker status foo*').to(:status) }
+  it { is_expected.to route_command('locker status foo* # comment').to(:status) }
 
   it do
     is_expected.to route_command('locker list @alice').to(:list)
     is_expected.to route_command('locker list Alice').to(:list)
+    is_expected.to route_command('locker list Alice # comment').to(:list)
   end
 
   it do
     is_expected.to route_command('locker log something').to(:log)
+    is_expected.to route_command('locker log something # comment').to(:log)
   end
 
   it do
     is_expected.to route_command('locker dequeue something something').to(:dequeue)
     is_expected.to route_command('locker dq something something').to(:dequeue)
+    is_expected.to route_command('locker dq something something # comment').to(:dequeue)
   end
 
   let(:alice) do

--- a/spec/lita/handlers/locker_resources_spec.rb
+++ b/spec/lita/handlers/locker_resources_spec.rb
@@ -12,6 +12,9 @@ describe Lita::Handlers::LockerResources, lita_handler: true do
       is_expected.to route_command("locker resource create #{r}").to(:create)
       is_expected.to route_command("locker resource delete #{r}").to(:delete)
       is_expected.to route_command("locker resource show #{r}").to(:show)
+      is_expected.to route_command("locker resource create #{r} # comment").to(:create)
+      is_expected.to route_command("locker resource delete #{r} # comment").to(:delete)
+      is_expected.to route_command("locker resource show #{r} # comment").to(:show)
     end
   end
 
@@ -25,6 +28,7 @@ describe Lita::Handlers::LockerResources, lita_handler: true do
   end
 
   it { is_expected.to route_command('locker resource list').to(:list) }
+  it { is_expected.to route_command('locker resource list # comment').to(:list) }
 
   describe '#resource_list' do
     it 'shows a list of resources if there are any' do


### PR DESCRIPTION
Previously, commands defined outside of locker.rb would not match routes
if they contained comments. This PR adds the comment regex to the chat
  routes where they were missing.