### PR TITLE
Send a single message on locker status * to avoid rate limiting

### DIFF
--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -58,9 +58,7 @@ module Lita
         matcher = Regexp.new(name.gsub(/\*/, '.*'))
         labels = Label.list.select { |label| label =~ matcher }
         return response.reply(failed(t('status.does_not_exist', name: name))) if labels.empty?
-        labels.each do |n|
-          response.reply(status_label(n))
-        end
+        response.reply(labels.map { |l| status_label(l) }.join("\n"))
       end
 
       def dequeue(response)

--- a/spec/lita/handlers/locker_misc_spec.rb
+++ b/spec/lita/handlers/locker_misc_spec.rb
@@ -135,8 +135,7 @@ describe Lita::Handlers::LockerMisc, lita_handler: true do
       send_command('locker label add bazbarluhrmann to bazbar')
       send_command('lock foobar')
       send_command('locker status foo*')
-      expect(replies[-2]).to match(/^foobar is locked by Test User \(taken \d seconds? ago\)$/)
-      expect(replies.last).to match(/^foobaz is unlocked$/)
+      expect(replies.last).to match(/^foobar is locked by Test User \(taken \d seconds? ago\)\nfoobaz is unlocked$/)
     end
 
     it 'shows an error if nothing exists with that name' do


### PR DESCRIPTION
Instead of sending a message for each individual label in response to a locker status wildcard search, the bot will now send a single message that shows all matching labels separated by newlines.