### PR TITLE
Paginate listed items

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ gem "lita-locker"
 
 ## Configuration
 
-None
+### Optional attributes
+
+* `per_page` - The number of items to show at once when listing labels or resources. Default: 10
+
+### Example
+
+``` ruby
+Lita.configure do |config|
+  config.handlers.locker.per_page = 3
+```
 
 ## Usage
 
@@ -61,7 +70,7 @@ locker dequeue <label> - Remove yourself from the queue for <label>
 
 ### Labels
 ```
-locker label list                          - List all labels
+locker label list [--page N]               - List all labels
 locker label create <name>                 - Create a label with <name>.
 locker label delete <name>                 - Delete the label with <name>.  Clears all locks associated.
 locker label add <resource> to <name>      - Adds <resource> to the list of things to lock/unlock for <name>
@@ -71,10 +80,10 @@ locker label show <name>                   - Show all resources for <name>
 
 ### Resources
 ```
-locker resource list          - List all resources
-locker resource create <name> - Create a resource with <name>.  (Restricted to locker_admins group)
-locker resource delete <name> - Delete the resource with <name>.  Clears all locks associated.  (Restricted to locker_admins group)
-locker resource show <name>   - Show the state of <name>
+locker resource list [--page N]   - List all resources
+locker resource create <name>     - Create a resource with <name>.  (Restricted to locker_admins group)
+locker resource delete <name>     - Delete the resource with <name>.  Clears all locks associated.  (Restricted to locker_admins group)
+locker resource show <name>       - Show the state of <name>
 ```
 
 ### HTTP access

--- a/lib/lita-locker.rb
+++ b/lib/lita-locker.rb
@@ -8,6 +8,7 @@ Lita.load_locales Dir[File.expand_path(
 
 require 'redis-objects'
 require 'time-lord'
+require 'lita-keyword-arguments'
 
 require 'locker/label'
 require 'locker/misc'

--- a/lib/lita/handlers/locker.rb
+++ b/lib/lita/handlers/locker.rb
@@ -5,6 +5,8 @@ module Lita
   module Handlers
     # Top-level class for Locker
     class Locker < Handler
+      config :per_page, type: Integer, default: 10
+
       on :loaded, :setup_redis
 
       include ::Locker::Label

--- a/lib/lita/handlers/locker_labels.rb
+++ b/lib/lita/handlers/locker_labels.rb
@@ -12,7 +12,7 @@ module Lita
       include ::Locker::Resource
 
       route(
-        /^locker\slabel\slist#{COMMENT_REGEX}/,
+        /^locker\slabel\slist/,
         :list,
         command: true,
         kwargs: { page: { default: 1 } },

--- a/lib/lita/handlers/locker_labels.rb
+++ b/lib/lita/handlers/locker_labels.rb
@@ -87,7 +87,7 @@ module Lita
           when 'locked'
             locked(t('label.desc', name: key, state: state))
           else
-            # This case shouldn't happen, but it will if someone a label
+            # This case shouldn't happen, but it will if a label
             # gets saved with some other value for `state`.
             t('label.desc', name: key, state: state)
           end

--- a/lib/lita/handlers/locker_labels.rb
+++ b/lib/lita/handlers/locker_labels.rb
@@ -60,16 +60,10 @@ module Lita
         begin
           list = ::Locker::List.new(Label, config.per_page, response.extensions[:kwargs][:page])
         rescue ArgumentError
-          response.reply t("list.invalid_page_type")
-
-          return
+          return response.reply(t('list.invalid_page_type'))
         end
 
-        unless list.valid_page?
-          response.reply t("list.page_outside_range", pages: list.pages)
-
-          return
-        end
+        return response.reply(t('list.page_outside_range', pages: list.pages)) unless list.valid_page?
 
         message = list.requested_page.map do |key|
           label = Label.new(key)
@@ -88,9 +82,7 @@ module Lita
           end
         end.join("\n")
 
-        if list.multiple_pages?
-          message += "\n#{t('list.paginate', page: list.page, pages: list.pages)}"
-        end
+        message += "\n#{t('list.paginate', page: list.page, pages: list.pages)}" if list.multiple_pages?
 
         response.reply(message)
       end

--- a/lib/lita/handlers/locker_resources.rb
+++ b/lib/lita/handlers/locker_resources.rb
@@ -52,16 +52,10 @@ module Lita
         begin
           list = ::Locker::List.new(Resource, config.per_page, response.extensions[:kwargs][:page])
         rescue ArgumentError
-          response.reply t("list.invalid_page_type")
-
-          return
+          return response.reply(t('list.invalid_page_type'))
         end
 
-        unless list.valid_page?
-          response.reply t("list.page_outside_range", pages: list.pages)
-
-          return
-        end
+        return response.reply(t('list.page_outside_range', pages: list.pages)) unless list.valid_page?
 
         message = list.requested_page.map do |key|
           resource = Resource.new(key)
@@ -80,9 +74,7 @@ module Lita
           end
         end.join("\n")
 
-        if list.multiple_pages?
-          message += "\n#{t('list.paginate', page: list.page, pages: list.pages)}"
-        end
+        message += "\n#{t('list.paginate', page: list.page, pages: list.pages)}" if list.multiple_pages?
 
         response.reply(message)
       end

--- a/lib/lita/handlers/locker_resources.rb
+++ b/lib/lita/handlers/locker_resources.rb
@@ -79,7 +79,7 @@ module Lita
           when 'locked'
             locked(t('resource.desc', name: key, state: state))
           else
-            # This case shouldn't happen, but it will if someone a label
+            # This case shouldn't happen, but it will if a label
             # gets saved with some other value for `state`.
             t('resource.desc', name: key, state: state)
           end

--- a/lib/lita/handlers/locker_resources.rb
+++ b/lib/lita/handlers/locker_resources.rb
@@ -12,7 +12,7 @@ module Lita
       include ::Locker::Resource
 
       route(
-        /^locker\sresource\slist#{COMMENT_REGEX}/,
+        /^locker\sresource\slist/,
         :list,
         command: true,
         kwargs: { page: { default: 1 } },

--- a/lib/lita/handlers/locker_resources.rb
+++ b/lib/lita/handlers/locker_resources.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'locker/list'
+
 module Lita
   module Handlers
     # Resource-related handlers
@@ -47,28 +49,21 @@ module Lita
       )
 
       def list(response)
-        list = Resource.list
-        count = list.count
-
         begin
-          page = Integer(response.extensions[:kwargs][:page].to_s, 10)
+          list = ::Locker::List.new(Resource, config.per_page, response.extensions[:kwargs][:page])
         rescue ArgumentError
           response.reply t("list.invalid_page_type")
 
           return
         end
 
-        pages = (count / config.per_page).ceil + 1
-
-        if page < 1 || page > pages
-          response.reply t("list.page_outside_range", pages: pages)
+        unless list.valid_page?
+          response.reply t("list.page_outside_range", pages: list.pages)
 
           return
         end
 
-        offset = config.per_page * (page - 1)
-
-        message = list[offset, config.per_page].map do |key|
+        message = list.requested_page.map do |key|
           resource = Resource.new(key)
 
           state = resource.state.value
@@ -85,8 +80,8 @@ module Lita
           end
         end.join("\n")
 
-        if count > config.per_page
-          message += "\n#{t('list.paginate', page: page, pages: pages)}"
+        if list.multiple_pages?
+          message += "\n#{t('list.paginate', page: list.page, pages: list.pages)}"
         end
 
         response.reply(message)

--- a/lib/lita/handlers/locker_resources.rb
+++ b/lib/lita/handlers/locker_resources.rb
@@ -12,9 +12,10 @@ module Lita
       include ::Locker::Resource
 
       route(
-        /^locker\sresource\slist#{COMMENT_REGEX}$/,
+        /^locker\sresource\slist#{COMMENT_REGEX}/,
         :list,
         command: true,
+        kwargs: { page: { default: 1 } },
         help: { t('help.resource.list.syntax') => t('help.resource.list.desc') }
       )
 
@@ -46,22 +47,49 @@ module Lita
       )
 
       def list(response)
-        after 0 do
-          should_rate_limit = false
+        list = Resource.list
+        count = list.count
 
-          Resource.list.each_slice(5) do |slice|
-            if should_rate_limit
-              sleep 3
-            else
-              should_rate_limit = true
-            end
+        begin
+          page = Integer(response.extensions[:kwargs][:page].to_s, 10)
+        rescue ArgumentError
+          response.reply t("list.invalid_page_type")
 
-            slice.each do |r|
-              res = Resource.new(r)
-              response.reply(t('resource.desc', name: r, state: res.state.value))
-            end
-          end
+          return
         end
+
+        pages = (count / config.per_page).ceil + 1
+
+        if page < 1 || page > pages
+          response.reply t("list.page_outside_range", pages: pages)
+
+          return
+        end
+
+        offset = config.per_page * (page - 1)
+
+        message = list[offset, config.per_page].map do |key|
+          resource = Resource.new(key)
+
+          state = resource.state.value
+
+          case state
+          when 'unlocked'
+            unlocked(t('resource.desc', name: key, state: state))
+          when 'locked'
+            locked(t('resource.desc', name: key, state: state))
+          else
+            # This case shouldn't happen, but it will if someone a label
+            # gets saved with some other value for `state`.
+            t('resource.desc', name: key, state: state)
+          end
+        end.join("\n")
+
+        if count > config.per_page
+          message += "\n#{t('list.paginate', page: page, pages: pages)}"
+        end
+
+        response.reply(message)
       end
 
       def create(response)

--- a/lib/locker/list.rb
+++ b/lib/locker/list.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Locker subsystem
+module Locker
+  # A paginated list of items (e.g. labels or resources).
+  #
+  # @api private
+  class List
+    # @return [#list] The Ruby class of the item to be listed.
+    attr_reader :item_class
+
+    # @return [Enumerable] The full list of items.
+    attr_reader :list
+
+    # @return [Integer] The number of items displayed per page.
+    attr_reader :per_page
+
+    # @return [Integer] The page the user has requested.
+    attr_reader :page
+
+    # @return [Integer] The total number of pages.
+    attr_reader :pages
+
+    # @return [Integer] The zero-based index offset that the requested page starts on within the full list.
+    attr_reader :offset
+
+    def initialize(item_class, per_page, page)
+      @item_class = item_class
+      @list = item_class.list
+      @per_page = per_page
+      @page = Integer(page.to_s, 10)
+      @pages = (list.count / per_page).ceil + 1
+      @offset = per_page * (self.page - 1)
+    end
+
+    # Whether or not the list has multiple pages.
+    #
+    # @return [Boolean]
+    def multiple_pages?
+      list.count > per_page
+    end
+
+    # An enumerable of the items in the requested page.
+    #
+    # @return [Enumerable]
+    def requested_page
+      list[offset, per_page]
+    end
+
+    # Whether or not the requested page exists.
+    #
+    # @return [Boolean]
+    def valid_page?
+      page >= 1 && page <= pages
+    end
+  end
+end

--- a/lita-locker.gemspec
+++ b/lita-locker.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'lita', '>= 4.2'
   spec.add_runtime_dependency 'redis-objects'
   spec.add_runtime_dependency 'time-lord'
+  spec.add_runtime_dependency 'lita-keyword-arguments'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'coveralls'

--- a/lita-locker.gemspec
+++ b/lita-locker.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.2'
+  spec.add_runtime_dependency 'lita-keyword-arguments'
   spec.add_runtime_dependency 'redis-objects'
   spec.add_runtime_dependency 'time-lord'
-  spec.add_runtime_dependency 'lita-keyword-arguments'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'coveralls'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -53,7 +53,7 @@ en:
             desc: Show what locks a user currently holds
           resource:
             list:
-              syntax: locker resource list
+              syntax: locker resource list [--page N]
               desc: List all resources
             create:
               syntax: "locker resource create <name>[, <name> ...]"
@@ -66,7 +66,7 @@ en:
               desc: Show the state of <name>
           label:
             list:
-              syntax: locker label list
+              syntax: locker label list [--page N]
               desc: List all labels
             create:
               syntax: "locker label create <name>[, <name> ...]"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,10 @@ en:
           already_observing: "%{user}, you are already observing %{name}"
           stopped_observing: "%{user}, you have stopped observing %{name}"
           were_not_observing: "%{user}, you were not observing %{name}"
+        list:
+          paginate: "Page %{page} of %{pages} shown. Use --page to specify additional pages."
+          invalid_page_type: "Page specified must be an integer."
+          page_outside_range: "Page specified must be between 1 and %{pages}."
         help:
           log:
             syntax: locker log <label>
@@ -105,7 +109,7 @@ en:
           unlocked_no_queue: "%{name} is unlocked and no one is next up %{mention}"
           unable_to_lock: "%{name} unable to be locked"
           lock: "%{name} locked"
-          desc: "%{name} is unlocked"
+          desc: "%{name} is %{state}"
           desc_owner: "%{name} is locked by %{owner_name} (taken %{time})"
           desc_owner_queue: "%{name} is locked by %{owner_name} (taken %{time}). Next up: %{queue}"
           created: "Label %{name} created"

--- a/spec/lita/handlers/locker_labels_spec.rb
+++ b/spec/lita/handlers/locker_labels_spec.rb
@@ -41,12 +41,62 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
 
   describe '#label_list' do
     it 'shows a list of labels if there are any' do
+      send_command('locker resource create whatever')
       send_command('locker label create foobar')
       send_command('locker label create bazbat')
+      send_command('locker label add whatever to bazbat')
+      send_command('lock bazbat')
       send_command('locker label list')
-      sleep 1 # TODO: HAAAACK.  Need after to have a more testable behavior.
-      expect(replies.include?('foobar is unlocked')).to eq(true)
-      expect(replies.include?('bazbat is unlocked')).to eq(true)
+      expect(replies.last).to include('foobar is unlocked')
+      expect(replies.last).to include('bazbat is locked')
+    end
+
+    context 'when per_page is configured to 3' do
+      before do
+        robot.config.handlers.locker.per_page = 3
+      end
+
+      it 'includes details about what page was shown' do
+        send_command('locker label create 1')
+        send_command('locker label create 2')
+        send_command('locker label create 3')
+        send_command('locker label create 4')
+        send_command('locker label list')
+        expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
+      end
+
+      it 'displays the page specified' do
+        send_command('locker label create 1')
+        send_command('locker label create 2')
+        send_command('locker label create 3')
+        send_command('locker label create 4')
+        send_command('locker label list --page 2')
+        expect(replies.last).to include("4 is unlocked")
+        expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
+      end
+
+      it 'rejects pages lower than 1' do
+        send_command('locker label create 1')
+        send_command('locker label create 2')
+        send_command('locker label create 3')
+        send_command('locker label create 4')
+        send_command('locker label list --page 0')
+        expect(replies.last).to eq("Page specified must be between 1 and 2.")
+      end
+
+      it 'rejects pages higher than the number there are' do
+        send_command('locker label create 1')
+        send_command('locker label create 2')
+        send_command('locker label create 3')
+        send_command('locker label create 4')
+        send_command('locker label list --page 3')
+        expect(replies.last).to eq("Page specified must be between 1 and 2.")
+      end
+
+      it 'rejects non-integer values for pages' do
+        send_command('locker label list --page x')
+        expect(replies.last).to eq("Page specified must be an integer.")
+      end
     end
   end
 

--- a/spec/lita/handlers/locker_labels_spec.rb
+++ b/spec/lita/handlers/locker_labels_spec.rb
@@ -66,29 +66,29 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
 
         it 'includes details about what page was shown' do
           send_command('locker label list')
-          expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
+          expect(replies.last).to include('Page 1 of 2 shown. Use --page to specify additional pages.')
         end
 
         it 'displays the page specified' do
           send_command('locker label list --page 2')
-          expect(replies.last).to include("4 is unlocked")
-          expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
+          expect(replies.last).to include('4 is unlocked')
+          expect(replies.last).to include('Page 2 of 2 shown. Use --page to specify additional pages.')
         end
 
         it 'rejects pages lower than 1' do
           send_command('locker label list --page 0')
-          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+          expect(replies.last).to eq('Page specified must be between 1 and 2.')
         end
 
         it 'rejects pages higher than the number there are' do
           send_command('locker label list --page 3')
-          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+          expect(replies.last).to eq('Page specified must be between 1 and 2.')
         end
       end
 
       it 'rejects non-integer values for pages' do
         send_command('locker label list --page x')
-        expect(replies.last).to eq("Page specified must be an integer.")
+        expect(replies.last).to eq('Page specified must be an integer.')
       end
     end
   end

--- a/spec/lita/handlers/locker_labels_spec.rb
+++ b/spec/lita/handlers/locker_labels_spec.rb
@@ -56,41 +56,34 @@ describe Lita::Handlers::LockerLabels, lita_handler: true do
         robot.config.handlers.locker.per_page = 3
       end
 
-      it 'includes details about what page was shown' do
-        send_command('locker label create 1')
-        send_command('locker label create 2')
-        send_command('locker label create 3')
-        send_command('locker label create 4')
-        send_command('locker label list')
-        expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
-      end
+      context 'when there are 4 labels' do
+        before do
+          send_command('locker label create 1')
+          send_command('locker label create 2')
+          send_command('locker label create 3')
+          send_command('locker label create 4')
+        end
 
-      it 'displays the page specified' do
-        send_command('locker label create 1')
-        send_command('locker label create 2')
-        send_command('locker label create 3')
-        send_command('locker label create 4')
-        send_command('locker label list --page 2')
-        expect(replies.last).to include("4 is unlocked")
-        expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
-      end
+        it 'includes details about what page was shown' do
+          send_command('locker label list')
+          expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
+        end
 
-      it 'rejects pages lower than 1' do
-        send_command('locker label create 1')
-        send_command('locker label create 2')
-        send_command('locker label create 3')
-        send_command('locker label create 4')
-        send_command('locker label list --page 0')
-        expect(replies.last).to eq("Page specified must be between 1 and 2.")
-      end
+        it 'displays the page specified' do
+          send_command('locker label list --page 2')
+          expect(replies.last).to include("4 is unlocked")
+          expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
+        end
 
-      it 'rejects pages higher than the number there are' do
-        send_command('locker label create 1')
-        send_command('locker label create 2')
-        send_command('locker label create 3')
-        send_command('locker label create 4')
-        send_command('locker label list --page 3')
-        expect(replies.last).to eq("Page specified must be between 1 and 2.")
+        it 'rejects pages lower than 1' do
+          send_command('locker label list --page 0')
+          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+        end
+
+        it 'rejects pages higher than the number there are' do
+          send_command('locker label list --page 3')
+          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+        end
       end
 
       it 'rejects non-integer values for pages' do

--- a/spec/lita/handlers/locker_resources_spec.rb
+++ b/spec/lita/handlers/locker_resources_spec.rb
@@ -56,29 +56,29 @@ describe Lita::Handlers::LockerResources, lita_handler: true do
 
         it 'includes details about what page was shown' do
           send_command('locker resource list')
-          expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
+          expect(replies.last).to include('Page 1 of 2 shown. Use --page to specify additional pages.')
         end
 
         it 'displays the page specified' do
           send_command('locker resource list --page 2')
-          expect(replies.last).to include("Resource: 4, state: unlocked")
-          expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
+          expect(replies.last).to include('Resource: 4, state: unlocked')
+          expect(replies.last).to include('Page 2 of 2 shown. Use --page to specify additional pages.')
         end
 
         it 'rejects pages lower than 1' do
           send_command('locker resource list --page 0')
-          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+          expect(replies.last).to eq('Page specified must be between 1 and 2.')
         end
 
         it 'rejects pages higher than the number there are' do
           send_command('locker resource list --page 3')
-          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+          expect(replies.last).to eq('Page specified must be between 1 and 2.')
         end
       end
 
       it 'rejects non-integer values for pages' do
         send_command('locker resource list --page x')
-        expect(replies.last).to eq("Page specified must be an integer.")
+        expect(replies.last).to eq('Page specified must be an integer.')
       end
     end
   end

--- a/spec/lita/handlers/locker_resources_spec.rb
+++ b/spec/lita/handlers/locker_resources_spec.rb
@@ -37,9 +37,56 @@ describe Lita::Handlers::LockerResources, lita_handler: true do
       send_command('locker resource create foobar')
       send_command('locker resource create bazbat')
       send_command('locker resource list')
-      sleep 1 # TODO: HAAAAACK.  Need after to have a more testable behavior.
-      expect(replies).to include('Resource: foobar, state: unlocked')
-      expect(replies).to include('Resource: bazbat, state: unlocked')
+      expect(replies.last).to include('Resource: foobar, state: unlocked')
+      expect(replies.last).to include('Resource: bazbat, state: unlocked')
+    end
+
+    context 'when per_page is configured to 3' do
+      before do
+        robot.config.handlers.locker.per_page = 3
+      end
+
+      it 'includes details about what page was shown' do
+        send_command('locker resource create 1')
+        send_command('locker resource create 2')
+        send_command('locker resource create 3')
+        send_command('locker resource create 4')
+        send_command('locker resource list')
+        expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
+      end
+
+      it 'displays the page specified' do
+        send_command('locker resource create 1')
+        send_command('locker resource create 2')
+        send_command('locker resource create 3')
+        send_command('locker resource create 4')
+        send_command('locker resource list --page 2')
+        expect(replies.last).to include("Resource: 4, state: unlocked")
+        expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
+      end
+
+      it 'rejects pages lower than 1' do
+        send_command('locker resource create 1')
+        send_command('locker resource create 2')
+        send_command('locker resource create 3')
+        send_command('locker resource create 4')
+        send_command('locker resource list --page 0')
+        expect(replies.last).to eq("Page specified must be between 1 and 2.")
+      end
+
+      it 'rejects pages higher than the number there are' do
+        send_command('locker resource create 1')
+        send_command('locker resource create 2')
+        send_command('locker resource create 3')
+        send_command('locker resource create 4')
+        send_command('locker resource list --page 3')
+        expect(replies.last).to eq("Page specified must be between 1 and 2.")
+      end
+
+      it 'rejects non-integer values for pages' do
+        send_command('locker resource list --page x')
+        expect(replies.last).to eq("Page specified must be an integer.")
+      end
     end
   end
 

--- a/spec/lita/handlers/locker_resources_spec.rb
+++ b/spec/lita/handlers/locker_resources_spec.rb
@@ -46,41 +46,34 @@ describe Lita::Handlers::LockerResources, lita_handler: true do
         robot.config.handlers.locker.per_page = 3
       end
 
-      it 'includes details about what page was shown' do
-        send_command('locker resource create 1')
-        send_command('locker resource create 2')
-        send_command('locker resource create 3')
-        send_command('locker resource create 4')
-        send_command('locker resource list')
-        expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
-      end
+      context 'when there are 4 resources' do
+        before do
+          send_command('locker resource create 1')
+          send_command('locker resource create 2')
+          send_command('locker resource create 3')
+          send_command('locker resource create 4')
+        end
 
-      it 'displays the page specified' do
-        send_command('locker resource create 1')
-        send_command('locker resource create 2')
-        send_command('locker resource create 3')
-        send_command('locker resource create 4')
-        send_command('locker resource list --page 2')
-        expect(replies.last).to include("Resource: 4, state: unlocked")
-        expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
-      end
+        it 'includes details about what page was shown' do
+          send_command('locker resource list')
+          expect(replies.last).to include("Page 1 of 2 shown. Use --page to specify additional pages.")
+        end
 
-      it 'rejects pages lower than 1' do
-        send_command('locker resource create 1')
-        send_command('locker resource create 2')
-        send_command('locker resource create 3')
-        send_command('locker resource create 4')
-        send_command('locker resource list --page 0')
-        expect(replies.last).to eq("Page specified must be between 1 and 2.")
-      end
+        it 'displays the page specified' do
+          send_command('locker resource list --page 2')
+          expect(replies.last).to include("Resource: 4, state: unlocked")
+          expect(replies.last).to include("Page 2 of 2 shown. Use --page to specify additional pages.")
+        end
 
-      it 'rejects pages higher than the number there are' do
-        send_command('locker resource create 1')
-        send_command('locker resource create 2')
-        send_command('locker resource create 3')
-        send_command('locker resource create 4')
-        send_command('locker resource list --page 3')
-        expect(replies.last).to eq("Page specified must be between 1 and 2.")
+        it 'rejects pages lower than 1' do
+          send_command('locker resource list --page 0')
+          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+        end
+
+        it 'rejects pages higher than the number there are' do
+          send_command('locker resource list --page 3')
+          expect(replies.last).to eq("Page specified must be between 1 and 2.")
+        end
       end
 
       it 'rejects non-integer values for pages' do

--- a/spec/locker/list_spec.rb
+++ b/spec/locker/list_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe Locker::List do
+  let(:item_class) { double("item class", list: [one, two, three, four]) }
+
+  let(:one) { double("one") }
+  let(:two) { double("two") }
+  let(:three) { double("three") }
+  let(:four) { double("four") }
+
+  it 'raises an argument error if a non-integer page is requested' do
+    expect { described_class.new(item_class, 3, "z") }.to raise_error(ArgumentError)
+  end
+
+  describe '#multiple_pages' do
+    it 'is true when there are more total items than can be displayed on one page' do
+      subject = described_class.new(item_class, 1, 1)
+
+      expect(subject).to be_multiple_pages
+    end
+
+    it 'is false when the whole list fits in one page' do
+      subject = described_class.new(item_class, 10, 1)
+
+      expect(subject).not_to be_multiple_pages
+    end
+  end
+
+  describe '#requested_page' do
+    context 'with an empty list' do
+      let(:item_class) { double("item class", list: []) }
+
+      it 'returns an empty list' do
+        subject = described_class.new(item_class, 3, 1)
+
+        expect(subject.requested_page).to be_empty
+      end
+    end
+
+    context 'with a single item list' do
+      let(:item_class) { double("item class", list: [one]) }
+
+      it 'returns a list with one item' do
+        subject = described_class.new(item_class, 3, 1)
+
+        expect(subject.requested_page).to eq([one])
+      end
+    end
+
+    context 'with a four item list' do
+      it 'splits the pages correctly when there are two items per page' do
+        subject = described_class.new(item_class, 2, 1)
+
+        expect(subject.requested_page).to eq([one, two])
+
+        subject = described_class.new(item_class, 2, 2)
+
+        expect(subject.requested_page).to eq([three, four])
+      end
+
+      it 'splits the pages correctly when there are three items per page' do
+        subject = described_class.new(item_class, 3, 1)
+
+        expect(subject.requested_page).to eq([one, two, three])
+
+        subject = described_class.new(item_class, 3, 2)
+
+        expect(subject.requested_page).to eq([four])
+      end
+    end
+  end
+
+  describe '#valid_page?' do
+    it 'is true when the first page is requested' do
+      subject = described_class.new(item_class, 3, 1)
+
+      expect(subject).to be_valid_page
+    end
+
+    it 'is true when the page is between 1 and the total number of pages' do
+      subject = described_class.new(item_class, 3, 2)
+
+      expect(subject).to be_valid_page
+    end
+
+    it 'is false when the page is less than 1' do
+      subject = described_class.new(item_class, 3, 0)
+
+      expect(subject).not_to be_valid_page
+    end
+
+    it 'is false when the page is greater than the total number of pages' do
+      subject = described_class.new(item_class, 3, 10)
+
+      expect(subject).not_to be_valid_page
+    end
+  end
+end

--- a/spec/locker/list_spec.rb
+++ b/spec/locker/list_spec.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Locker::List do
-  let(:item_class) { double("item class", list: [one, two, three, four]) }
+  let(:item_class) { double('item class', list: [one, two, three, four]) }
 
-  let(:one) { double("one") }
-  let(:two) { double("two") }
-  let(:three) { double("three") }
-  let(:four) { double("four") }
+  let(:one) { double('one') }
+  let(:two) { double('two') }
+  let(:three) { double('three') }
+  let(:four) { double('four') }
 
   it 'raises an argument error if a non-integer page is requested' do
-    expect { described_class.new(item_class, 3, "z") }.to raise_error(ArgumentError)
+    expect { described_class.new(item_class, 3, 'z') }.to raise_error(ArgumentError)
   end
 
   describe '#multiple_pages' do
@@ -28,7 +30,7 @@ describe Locker::List do
 
   describe '#requested_page' do
     context 'with an empty list' do
-      let(:item_class) { double("item class", list: []) }
+      let(:item_class) { double('item class', list: []) }
 
       it 'returns an empty list' do
         subject = described_class.new(item_class, 3, 1)
@@ -38,7 +40,7 @@ describe Locker::List do
     end
 
     context 'with a single item list' do
-      let(:item_class) { double("item class", list: [one]) }
+      let(:item_class) { double('item class', list: [one]) }
 
       it 'returns a list with one item' do
         subject = described_class.new(item_class, 3, 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,13 +14,15 @@ Lita.version_3_compatibility_mode = false
 
 RSpec.configure do |config|
   config.before do
-    registry.register_hook(:trigger_route, Lita::Extensions::KeywordArguments)
-    registry.register_handler(Lita::Handlers::Locker)
-    registry.register_handler(Lita::Handlers::LockerEvents)
-    registry.register_handler(Lita::Handlers::LockerHttp)
-    registry.register_handler(Lita::Handlers::LockerLabels)
-    registry.register_handler(Lita::Handlers::LockerMisc)
-    registry.register_handler(Lita::Handlers::LockerResources)
+    if defined? registry
+      registry.register_hook(:trigger_route, Lita::Extensions::KeywordArguments)
+      registry.register_handler(Lita::Handlers::Locker)
+      registry.register_handler(Lita::Handlers::LockerEvents)
+      registry.register_handler(Lita::Handlers::LockerHttp)
+      registry.register_handler(Lita::Handlers::LockerLabels)
+      registry.register_handler(Lita::Handlers::LockerMisc)
+      registry.register_handler(Lita::Handlers::LockerResources)
+    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ Lita.version_3_compatibility_mode = false
 
 RSpec.configure do |config|
   config.before do
+    registry.register_hook(:trigger_route, Lita::Extensions::KeywordArguments)
     registry.register_handler(Lita::Handlers::Locker)
     registry.register_handler(Lita::Handlers::LockerEvents)
     registry.register_handler(Lita::Handlers::LockerHttp)


### PR DESCRIPTION
To prevent large collections of labels and resources from flooding the chat when listed, display only up to the first N items and provide a keyword argument for displaying additional pages.

Example:

Before:

```
 You: Lita, locker label list
Lita: foo is unlocked
Lita: bar is unlocked
Lita: baz is unlocked
Lita: qux is unlocked
```

After, with the new `config.per_page` set to `3`:

```
 You: Lita, locker label list
Lita: foo is unlocked
      bar is unlocked
      baz is unlocked
      Page 1 of 2 shown. Use --page to specify additional pages.
 You: Lita, locker label list --page 2
Lita: 4 is unlocked
      Page 2 of 2 shown. Use --page to specify additional pages.
```