### PR TITLE
Fix a couple `NoMethodError` bugs.

### DIFF
--- a/lib/lita/handlers/locker.rb
+++ b/lib/lita/handlers/locker.rb
@@ -76,7 +76,7 @@ module Lita
 
         return response.reply(failed(t('label.does_not_exist', name: name))) unless Label.exists?(name)
         l = Label.new(name)
-        return response.reply(failed(t('label.no_resources', name: name))) unless l.membership.count.positive?
+        return response.reply(failed(t('label.no_resources', name: name))) unless l.membership.count > 0
         return response.reply(t('label.self_lock', name: name, user: response.user.name)) if l.owner == response.user
         return response.reply(success(t('label.lock', name: name))) if l.lock!(response.user.id)
 

--- a/lib/lita/handlers/locker_misc.rb
+++ b/lib/lita/handlers/locker_misc.rb
@@ -50,7 +50,7 @@ module Lita
 
       def status(response)
         name = response.match_data['label']
-        unless name.match?(/\*/)
+        unless name.match(/\*/)
           # Literal query
           return response.reply(status_label(name)) if Label.exists?(name)
           return response.reply(status_resource(name)) if Resource.exists?(name)


### PR DESCRIPTION
* Fix bad attempt to call `Numeric#positive?`
* Fix bad attempt to call `String#match?`

These methods don't exist. Perhaps they were previously being loaded from some core extension which is no longer being loaded. Both of these are causing crashes for PD's Lita instance.